### PR TITLE
common: Add support for AUDIO_FORMAT_PCM_24_BIT_PACKED.

### DIFF
--- a/src/common/droid-util-audio.h
+++ b/src/common/droid-util-audio.h
@@ -90,7 +90,8 @@ uint32_t conversion_table_format[][2] = {
     { PA_SAMPLE_U8,             AUDIO_FORMAT_PCM_8_BIT              },
     { PA_SAMPLE_S16LE,          AUDIO_FORMAT_PCM_16_BIT             },
     { PA_SAMPLE_S32LE,          AUDIO_FORMAT_PCM_32_BIT             },
-    { PA_SAMPLE_S24LE,          AUDIO_FORMAT_PCM_8_24_BIT           }
+    { PA_SAMPLE_S24LE,          AUDIO_FORMAT_PCM_8_24_BIT           },
+    { PA_SAMPLE_S24LE,          AUDIO_FORMAT_PCM_24_BIT_PACKED      }
 };
 
 uint32_t conversion_table_default_audio_source[][2] = {
@@ -424,6 +425,7 @@ struct string_conversion string_conversion_table_format[] = {
     STRING_ENTRY( AUDIO_FORMAT_PCM_8_BIT                            ),
     STRING_ENTRY( AUDIO_FORMAT_PCM_32_BIT                           ),
     STRING_ENTRY( AUDIO_FORMAT_PCM_8_24_BIT                         ),
+    STRING_ENTRY( AUDIO_FORMAT_PCM_24_BIT_PACKED                    ),
 
     { 0, NULL }
 };


### PR DESCRIPTION
Hello, my device is using `AUDIO_FORMAT_PCM_24_BIT_PACKED` in `audio_policy_configuration.xml`:

```xml
<mixPort name="primary output" role="source" flags="AUDIO_OUTPUT_FLAG_FAST|AUDIO_OUTPUT_FLAG_PRIMARY">
                    <profile name="" format="AUDIO_FORMAT_PCM_24_BIT_PACKED"
                             samplingRates="48000" channelMasks="AUDIO_CHANNEL_OUT_STEREO"/>
```
(file is from https://github.com/LineageOS/android_device_xiaomi_sdm845-common/blob/lineage-18.1/audio/audio_policy_configuration.xml)

And this caused errors in pulseaudio log and no valid sink in `pactl list`:

(latest log first)
```
10月 22 16:42:54 sfc-mix2s pulseaudio[16527]: Failed to open output stream.
10月 22 16:42:54 sfc-mix2s pulseaudio[16527]: Couldn't find compatible configuration for mix port "deep_buffer"
10月 22 16:42:54 sfc-mix2s pulseaudio[16527]: Open output stream "deep_buffer"->"Speaker".
10月 22 16:42:54 sfc-mix2s pulseaudio[16527]: Create new droid-sink
10月 22 16:42:54 sfc-mix2s pulseaudio[16527]: Failed to open output stream.
10月 22 16:42:54 sfc-mix2s pulseaudio[16527]: Couldn't find compatible configuration for mix port "primary output"
10月 22 16:42:54 sfc-mix2s pulseaudio[16527]: Open output stream "primary output"->"Speaker".
10月 22 16:42:54 sfc-mix2s pulseaudio[16527]: Create new droid-sink

...

10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:178] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:178] Unknown format entries: AUDIO_FORMAT_PCM_FLOAT
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:172] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:172] Unknown format entries: AUDIO_FORMAT_PCM_24_BIT_
PACKED
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:142] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:142] Unknown format entries: AUDIO_FORMAT_AAC_ADTS_HE
_V2
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:139] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:139] Unknown format entries: AUDIO_FORMAT_AAC_ADTS_HE
_V1
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:136] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:136] Unknown format entries: AUDIO_FORMAT_AAC_ADTS_LC
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:133] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:133] Unknown format entries: AUDIO_FORMAT_WMA_PRO
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:130] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:130] Unknown format entries: AUDIO_FORMAT_WMA
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:127] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:127] Unknown format entries: AUDIO_FORMAT_DTS_HD
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:124] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:124] Unknown format entries: AUDIO_FORMAT_DTS
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:121] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:121] Unknown format entries: AUDIO_FORMAT_AAC_HE_V2
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:118] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:118] Unknown format entries: AUDIO_FORMAT_AAC_HE_V1
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:115] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:115] Unknown format entries: AUDIO_FORMAT_AAC_LC
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:112] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:112] Unknown format entries: AUDIO_FORMAT_APE
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:109] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:109] Unknown format entries: AUDIO_FORMAT_ALAC
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:94] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:94] Unknown format entries: AUDIO_FORMAT_PCM_24_BIT_P
ACKED
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:73] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:73] Unknown format entries: AUDIO_FORMAT_PCM_24_BIT_P
ACKED
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:63] Ignore profile with unknown format.
10月 22 16:42:53 sfc-mix2s pulseaudio[16527]: [/vendor/etc/audio_policy_configuration.xml:63] Unknown format entries: AUDIO_FORMAT_PCM_24_BIT_P
ACKED
```

I'm wondering if this would be fixed when I add `AUDIO_FORMAT_PCM_24_BIT_PACKED` to `src/common/droid-util-audio.h`? Because I have no idea how to compile this (no document on droidian/porting-guide) ... any tips on compiling this module and update it to a device?
Thanks very much!